### PR TITLE
Enhance annotation editing

### DIFF
--- a/src/components/Annotation/PolygonAnnotationComponent.tsx
+++ b/src/components/Annotation/PolygonAnnotationComponent.tsx
@@ -1,28 +1,59 @@
 'use client';
 
-import { memo } from 'react';
-import { Line } from 'react-konva';
+import { memo, useCallback } from 'react';
+import { Line, Circle, Group } from 'react-konva';
+import type Konva from 'konva';
 import type { PolygonAnnotation as PolygonAnnotationType } from '@/types';
 
 interface PolygonAnnotationProps {
   annotation: PolygonAnnotationType;
   isSelected?: boolean;
+  onUpdate?: (updatedAnnotation: Partial<PolygonAnnotationType>) => void;
+  onSelect?: () => void;
 }
 
 export const PolygonAnnotation = memo(function PolygonAnnotation({
   annotation,
   isSelected = false,
+  onUpdate,
+  onSelect,
 }: PolygonAnnotationProps) {
   const { points, color } = annotation;
 
+  const handlePointDragMove = useCallback(
+    (index: number, e: Konva.KonvaEventObject<DragEvent>) => {
+      if (!onUpdate) return;
+      const position = e.target.position();
+      const updatedPoints = points.map((p, i) =>
+        i === index ? { x: position.x, y: position.y } : p,
+      );
+      onUpdate({ points: updatedPoints });
+    },
+    [onUpdate, points],
+  );
+
   return (
-    <Line
-      points={points.flatMap((point) => [point.x, point.y])}
-      fill={color || 'rgba(0, 255, 0, 0.5)'}
-      stroke={isSelected ? '#000' : 'transparent'}
-      strokeWidth={isSelected ? 2 : 0}
-      closed
-      listening={true}
-    />
+    <Group onClick={onSelect}>
+      <Line
+        points={points.flatMap((point) => [point.x, point.y])}
+        fill={color || 'rgba(0, 255, 0, 0.5)'}
+        stroke={isSelected ? '#000' : 'transparent'}
+        strokeWidth={isSelected ? 2 : 0}
+        closed
+        listening={true}
+      />
+      {isSelected &&
+        points.map((point, idx) => (
+          <Circle
+            key={idx}
+            x={point.x}
+            y={point.y}
+            radius={5}
+            fill="#000"
+            draggable
+            onDragMove={(e) => handlePointDragMove(idx, e)}
+          />
+        ))}
+    </Group>
   );
 });

--- a/src/components/Annotation/RectangleAnnotationComponent.tsx
+++ b/src/components/Annotation/RectangleAnnotationComponent.tsx
@@ -8,12 +8,14 @@ import type Konva from 'konva';
 interface RectangleAnnotationProps {
   annotation: RectangleAnnotation;
   onUpdate: (updatedAnnotation: Partial<RectangleAnnotation>) => void;
+  onSelect?: () => void;
   isSelected?: boolean;
 }
 
 export const RectangleAnnotationComponent = memo(function RectangleAnnotationComponent({
   annotation,
   onUpdate,
+  onSelect,
   isSelected = false,
 }: RectangleAnnotationProps) {
   const handleRef = useRef<Konva.Circle>(null);
@@ -76,7 +78,7 @@ export const RectangleAnnotationComponent = memo(function RectangleAnnotationCom
   }, [annotation.x, annotation.y, onUpdate]);
 
   return (
-    <Group>
+    <Group onClick={onSelect}>
       <Rect
         x={annotation.x}
         y={annotation.y}

--- a/src/components/Annotation/SegmentAnnotationComponent.tsx
+++ b/src/components/Annotation/SegmentAnnotationComponent.tsx
@@ -1,30 +1,61 @@
 'use client';
 
-import { memo } from 'react';
-import { Line } from 'react-konva';
+import { memo, useCallback } from 'react';
+import { Line, Circle, Group } from 'react-konva';
+import type Konva from 'konva';
 import type { SegmentAnnotation } from '@/types';
 
 interface SegmentAnnotationProps {
   annotation: SegmentAnnotation;
   isSelected?: boolean;
+  onUpdate?: (updatedAnnotation: Partial<SegmentAnnotation>) => void;
+  onSelect?: () => void;
 }
 
 export const SegmentAnnotationComponent = memo(
   function SegmentAnnotationComponent({
     annotation,
     isSelected = false,
+    onUpdate,
+    onSelect,
   }: SegmentAnnotationProps) {
     const { points, color } = annotation;
 
+    const handlePointDragMove = useCallback(
+      (idx: number, e: Konva.KonvaEventObject<DragEvent>) => {
+        if (!onUpdate) return;
+        const position = e.target.position();
+        const updatedPoints = points.map((p, i) =>
+          i === idx ? { x: position.x, y: position.y } : p,
+        );
+        onUpdate({ points: updatedPoints });
+      },
+      [onUpdate, points],
+    );
+
     return (
-      <Line
-        points={points.flatMap((point) => [point.x, point.y])}
-        fill={color || 'rgba(0, 255, 0, 0.5)'}
-        stroke={isSelected ? '#000' : 'transparent'}
-        strokeWidth={isSelected ? 2 : 0}
-        closed
-        listening={true}
-      />
+      <Group onClick={onSelect}>
+        <Line
+          points={points.flatMap((point) => [point.x, point.y])}
+          fill={color || 'rgba(0, 255, 0, 0.5)'}
+          stroke={isSelected ? '#000' : 'transparent'}
+          strokeWidth={isSelected ? 2 : 0}
+          closed
+          listening={true}
+        />
+        {isSelected &&
+          points.map((p, idx) => (
+            <Circle
+              key={idx}
+              x={p.x}
+              y={p.y}
+              radius={5}
+              fill="#000"
+              draggable
+              onDragMove={(e) => handlePointDragMove(idx, e)}
+            />
+          ))}
+      </Group>
     );
   },
 );

--- a/src/components/EditAnnotationUI/EditAnnotationUI.tsx
+++ b/src/components/EditAnnotationUI/EditAnnotationUI.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { memo, useEffect, useState } from 'react';
+import { useAnnotation } from '@/contexts/AnnotationContext';
 import type { Annotation } from '@/types';
 import { labelToColor } from '@/utils/color';
 
@@ -20,6 +21,7 @@ export const EditAnnotationUI = memo(function EditAnnotationUI({
   annotation,
   onUpdate,
 }: EditAnnotationUIProps) {
+  const { removeAnnotation } = useAnnotation();
   const [label, setLabel] = useState('');
   const [color, setColor] = useState('');
 
@@ -83,6 +85,13 @@ export const EditAnnotationUI = memo(function EditAnnotationUI({
         <div className="text-sm text-gray-500">
           タイプ: {annotation.type === 'rectangle' ? '矩形' : 'ポリゴン'}
         </div>
+        <button
+          type="button"
+          onClick={() => removeAnnotation(annotation.id)}
+          className="w-full rounded-md bg-red-600 text-white py-2 mt-2 hover:bg-red-500"
+        >
+          削除
+        </button>
       </form>
     </div>
   );

--- a/src/components/ImageDisplayArea/ImageDisplayArea.tsx
+++ b/src/components/ImageDisplayArea/ImageDisplayArea.tsx
@@ -209,18 +209,27 @@ export const ImageDisplayArea = memo(function ImageDisplayArea({
                   onUpdate={(updatedAnnotation) =>
                     handleAnnotationUpdate(annotation.id, updatedAnnotation)
                   }
+                  onSelect={() => selectAnnotation(annotation.id)}
                   isSelected={selectedAnnotationId === annotation.id}
                 />
               ) : annotation.type === 'polygon' ? (
                 <PolygonAnnotation
                   key={annotation.id}
                   annotation={annotation}
+                  onUpdate={(updatedAnnotation) =>
+                    handleAnnotationUpdate(annotation.id, updatedAnnotation)
+                  }
+                  onSelect={() => selectAnnotation(annotation.id)}
                   isSelected={selectedAnnotationId === annotation.id}
                 />
               ) : (
                 <SegmentAnnotationComponent
                   key={annotation.id}
                   annotation={annotation as SegmentAnnotation}
+                  onUpdate={(updatedAnnotation) =>
+                    handleAnnotationUpdate(annotation.id, updatedAnnotation)
+                  }
+                  onSelect={() => selectAnnotation(annotation.id)}
                   isSelected={selectedAnnotationId === annotation.id}
                 />
               ),


### PR DESCRIPTION
## Summary
- make rectangles, polygons, and segments selectable by clicking
- enable dragging polygon/segment points to edit shapes
- add Delete button to EditAnnotationUI

## Testing
- `yarn lint` *(fails: package missing in lockfile)*