### PR TITLE
Add local image loading support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,9 @@
-import { memo } from 'react';
+import { memo, useState } from 'react';
 import { ImageDisplayArea } from './components/ImageDisplayArea';
-import { AnnotationProvider } from './contexts/AnnotationContext';
+import {
+  AnnotationProvider,
+  useAnnotation,
+} from './contexts/AnnotationContext';
 import { Sidebar } from './components/Sidebar';
 
 const DEFAULT_IMAGE_URL = 'https://i.gzn.jp/img/2009/06/18/lenna/000.jpg';
@@ -9,15 +12,76 @@ export const App = memo(function App() {
   return (
     <div className="min-h-screen bg-gray-100">
       <AnnotationProvider>
-        <div className="flex">
-          <Sidebar />
-          <main className="flex-1 ml-64 p-4">
-            <ImageDisplayArea imageUrl={DEFAULT_IMAGE_URL} />
-          </main>
-        </div>
+        <AppContent />
       </AnnotationProvider>
     </div>
   );
 });
+
+function AppContent() {
+  const { clearAnnotations } = useAnnotation();
+  const [imageUrls, setImageUrls] = useState<string[]>([DEFAULT_IMAGE_URL]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const handleImagesLoaded = (urls: string[]) => {
+    if (urls.length > 0) {
+      setImageUrls(urls);
+      setCurrentIndex(0);
+      clearAnnotations();
+    }
+  };
+
+  const showPrev = () => {
+    if (currentIndex > 0) {
+      setCurrentIndex(currentIndex - 1);
+      clearAnnotations();
+    }
+  };
+
+  const showNext = () => {
+    if (currentIndex < imageUrls.length - 1) {
+      setCurrentIndex(currentIndex + 1);
+      clearAnnotations();
+    }
+  };
+
+  return (
+    <div className="flex">
+      <Sidebar onImagesLoaded={handleImagesLoaded} />
+      <main className="flex-1 ml-64 p-4">
+        <ImageDisplayArea imageUrl={imageUrls[currentIndex]} />
+        {imageUrls.length > 1 && (
+          <div className="flex justify-center items-center mt-4 gap-4">
+            <button
+              onClick={showPrev}
+              disabled={currentIndex === 0}
+              className={`px-4 py-2 rounded text-white ${
+                currentIndex === 0
+                  ? 'bg-gray-400 cursor-not-allowed'
+                  : 'bg-blue-600 hover:bg-blue-500'
+              }`}
+            >
+              前へ
+            </button>
+            <span>
+              {currentIndex + 1} / {imageUrls.length}
+            </span>
+            <button
+              onClick={showNext}
+              disabled={currentIndex === imageUrls.length - 1}
+              className={`px-4 py-2 rounded text-white ${
+                currentIndex === imageUrls.length - 1
+                  ? 'bg-gray-400 cursor-not-allowed'
+                  : 'bg-blue-600 hover:bg-blue-500'
+              }`}
+            >
+              次へ
+            </button>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
 
 export default App;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,18 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { AnnotationProvider } from '@/contexts/AnnotationContext';
+import { useState } from 'react';
+import {
+  AnnotationProvider,
+  useAnnotation,
+} from '@/contexts/AnnotationContext';
 import { Sidebar } from '@/components/Sidebar';
 
 // Konvaコンポーネントをクライアントサイドでのみ読み込む
 const ImageDisplayArea = dynamic(
-  () => import('@/components/ImageDisplayArea').then(mod => mod.ImageDisplayArea),
-  { ssr: false }
+  () =>
+    import('@/components/ImageDisplayArea').then((mod) => mod.ImageDisplayArea),
+  { ssr: false },
 );
 
 const DEFAULT_IMAGE_URL = 'https://i.gzn.jp/img/2009/06/18/lenna/000.jpg';
@@ -16,13 +21,74 @@ export default function Home() {
   return (
     <div className="min-h-screen bg-gray-100">
       <AnnotationProvider>
-        <div className="flex">
-          <Sidebar />
-          <main className="flex-1 ml-64 p-4">
-            <ImageDisplayArea imageUrl={DEFAULT_IMAGE_URL} />
-          </main>
-        </div>
+        <HomeContent />
       </AnnotationProvider>
     </div>
   );
-} 
+}
+
+function HomeContent() {
+  const { clearAnnotations } = useAnnotation();
+  const [imageUrls, setImageUrls] = useState<string[]>([DEFAULT_IMAGE_URL]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const handleImagesLoaded = (urls: string[]) => {
+    if (urls.length > 0) {
+      setImageUrls(urls);
+      setCurrentIndex(0);
+      clearAnnotations();
+    }
+  };
+
+  const showPrev = () => {
+    if (currentIndex > 0) {
+      setCurrentIndex(currentIndex - 1);
+      clearAnnotations();
+    }
+  };
+
+  const showNext = () => {
+    if (currentIndex < imageUrls.length - 1) {
+      setCurrentIndex(currentIndex + 1);
+      clearAnnotations();
+    }
+  };
+
+  return (
+    <div className="flex">
+      <Sidebar onImagesLoaded={handleImagesLoaded} />
+      <main className="flex-1 ml-64 p-4">
+        <ImageDisplayArea imageUrl={imageUrls[currentIndex]} />
+        {imageUrls.length > 1 && (
+          <div className="flex justify-center items-center mt-4 gap-4">
+            <button
+              onClick={showPrev}
+              disabled={currentIndex === 0}
+              className={`px-4 py-2 rounded text-white ${
+                currentIndex === 0
+                  ? 'bg-gray-400 cursor-not-allowed'
+                  : 'bg-blue-600 hover:bg-blue-500'
+              }`}
+            >
+              前へ
+            </button>
+            <span>
+              {currentIndex + 1} / {imageUrls.length}
+            </span>
+            <button
+              onClick={showNext}
+              disabled={currentIndex === imageUrls.length - 1}
+              className={`px-4 py-2 rounded text-white ${
+                currentIndex === imageUrls.length - 1
+                  ? 'bg-gray-400 cursor-not-allowed'
+                  : 'bg-blue-600 hover:bg-blue-500'
+              }`}
+            >
+              次へ
+            </button>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/components/ImageLoader/ImageLoader.tsx
+++ b/src/components/ImageLoader/ImageLoader.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { memo } from 'react';
+
+interface ImageLoaderProps {
+  onImagesLoaded: (urls: string[]) => void;
+}
+
+export const ImageLoader = memo(function ImageLoader({
+  onImagesLoaded,
+}: ImageLoaderProps) {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { files } = e.target;
+    if (!files) return;
+    const urls = Array.from(files).map((file) => URL.createObjectURL(file));
+    onImagesLoaded(urls);
+  };
+
+  return (
+    <div className="w-full p-4 bg-white rounded-lg shadow mb-4">
+      <h2 className="text-lg font-bold mb-2">画像読み込み</h2>
+      <input
+        type="file"
+        accept="image/*"
+        multiple
+        onChange={handleChange}
+        ref={(input) => {
+          if (input) {
+            input.setAttribute('directory', '');
+            input.setAttribute('webkitdirectory', '');
+          }
+        }}
+        className="w-full"
+      />
+    </div>
+  );
+});

--- a/src/components/ImageLoader/index.ts
+++ b/src/components/ImageLoader/index.ts
@@ -1,0 +1,1 @@
+export * from './ImageLoader';

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -3,12 +3,17 @@
 import { memo } from 'react';
 import { DownloadButton } from '@/components/DownloadButton';
 import { AnnotationTypeSelector } from '@/components/AnnotationTypeSelector/AnnotationTypeSelector';
+import { ImageLoader } from '@/components/ImageLoader';
 
-export const Sidebar = memo(function Sidebar() {
+interface SidebarProps {
+  onImagesLoaded?: (urls: string[]) => void;
+}
+export const Sidebar = memo(function Sidebar({ onImagesLoaded }: SidebarProps) {
   return (
     <aside className="fixed top-0 left-0 h-screen w-64 bg-gray-800 text-white p-4 shadow-lg overflow-y-auto">
       <h1 className="text-2xl font-bold mb-8">AnyLabel</h1>
       <div className="space-y-4">
+        {onImagesLoaded && <ImageLoader onImagesLoaded={onImagesLoaded} />}
         <AnnotationTypeSelector />
         <DownloadButton />
       </div>

--- a/src/contexts/AnnotationContext.tsx
+++ b/src/contexts/AnnotationContext.tsx
@@ -17,6 +17,7 @@ interface AnnotationContextType {
   removeAnnotation: (annotationId: string) => void;
   selectAnnotation: (annotationId: string | undefined) => void;
   setAnnotationType: (type: AnnotationType) => void;
+  clearAnnotations: () => void;
 }
 
 const AnnotationContext = createContext<AnnotationContextType | null>(null);
@@ -68,6 +69,11 @@ export function AnnotationProvider({ children }: AnnotationProviderProps) {
     [selectedAnnotationId],
   );
 
+  const clearAnnotations = useCallback(() => {
+    setAnnotations([]);
+    setSelectedAnnotationId(undefined);
+  }, []);
+
   const selectAnnotation = useCallback((annotationId: string | undefined) => {
     setSelectedAnnotationId(annotationId);
   }, []);
@@ -85,6 +91,7 @@ export function AnnotationProvider({ children }: AnnotationProviderProps) {
     removeAnnotation,
     selectAnnotation,
     setAnnotationType,
+    clearAnnotations,
   };
 
   return (


### PR DESCRIPTION
## Summary
- allow clearing annotations
- add ImageLoader component for selecting files or folders
- update sidebar to show ImageLoader
- load selected images and navigate between them

## Testing
- `npx prettier --write src/components/ImageLoader/ImageLoader.tsx src/components/Sidebar/Sidebar.tsx src/app/page.tsx src/App.tsx src/contexts/AnnotationContext.tsx`
- `npx eslint src` *(fails: ESLint couldn't find a config file)*